### PR TITLE
Add stdio MCP server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ For Claude Code, add a project-scoped `.mcp.json` file at the repository root:
   "mcpServers": {
     "ccfrank": {
       "command": "npx",
-      "args": ["-y", "ccfrank-mcp"],
+      "args": ["-y", "ccfrank"],
       "env": {}
     }
   }

--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ Clone CCFrank to a directory.
 
 <img src="./img/load_unpacked.png" height="300" alt="Load Extension">
 
+## MCP Server
+
+CCFrank can also run as a local `stdio` MCP server.
+
+For Claude Code, add a project-scoped `.mcp.json` file at the repository root:
+
+```json
+{
+  "mcpServers": {
+    "ccfrank": {
+      "command": "npx",
+      "args": ["-y", "ccfrank-mcp"],
+      "env": {}
+    }
+  }
+}
+```
+
 ## What's New
 
 **Version 4.5.5**

--- a/js/ccf.js
+++ b/js/ccf.js
@@ -10,6 +10,9 @@ ccf.getRankInfo = function (refine, type) {
   let rankInfo = {};
   rankInfo.ranks = [];
   rankInfo.info = "";
+  rankInfo.sourceKey = null;
+  rankInfo.canonicalName = null;
+  rankInfo.abbrName = null;
   let rank;
   let url;
   if (type == "url") {
@@ -43,10 +46,14 @@ ccf.getRankInfo = function (refine, type) {
     rank = "none";
     rankInfo.info += "Not Found\n";
   } else {
-    rankInfo.info += ccf.rankFullName[url];
-    let abbrname = ccf.rankAbbrName[url];
-    if (abbrname != "") {
-      rankInfo.info += " (" + abbrname + ")";
+    let canonicalName = ccf.rankFullName[url] || "";
+    let abbrName = ccf.rankAbbrName[url] || "";
+    rankInfo.sourceKey = url;
+    rankInfo.canonicalName = canonicalName || null;
+    rankInfo.abbrName = abbrName || null;
+    rankInfo.info += canonicalName;
+    if (abbrName != "") {
+      rankInfo.info += " (" + abbrName + ")";
     }
     if (rank == "E") {
       rankInfo.info += ": Expanded\n";

--- a/mcp/SKILL.md
+++ b/mcp/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: ccfrank
+description: 查询会议/期刊的 CCF 等级。当用户提到 CCF 等级、论文评级、会议排名、期刊等级，或需要查询某个会议/期刊是 CCF-A/B/C 时使用此技能。支持通过会议简称（如 PLDI、ICSE）、全称、或 DBLP URL 查询。
+version: 1.0.3
+homepage: https://github.com/m2kar/CCFrank4dblp
+dependencies:
+  npm:
+    - name: ccfrank
+      version: 4.5.5
+      integrity: sha512-prt+kEYsjfJdS7znEaubzjBw6TSTgK0+fHCGG2E16D9Gk8kzwDOhrIVPf+wACFpoNUzNH6con9vNjemMc6YnzA==
+      tarball: https://registry.npmjs.org/ccfrank/-/ccfrank-4.5.5.tgz
+      sourceRepo: https://github.com/m2kar/CCFrank4dblp
+install:
+  method: local-npm
+  lockVersion: true
+  allowGlobalInstall: false
+  execution:
+    command: ./node_modules/.bin/ccfrank
+---
+
+# CCFrank
+
+查询会议/期刊的 CCF 等级（A/B/C/E/P/none）。
+
+## 安装配置（MCP）
+
+先在隔离目录安装固定版本（避免全局安装、避免运行时动态下载执行）：
+
+```bash
+mkdir -p ~/.ccfrank-mcp
+cd ~/.ccfrank-mcp
+npm init -y
+npm install --save-exact ccfrank@4.5.5
+```
+
+```json
+{
+  "mcpServers": {
+    "ccfrank": {
+      "command": "/Users/<your-user>/.ccfrank-mcp/node_modules/.bin/ccfrank",
+      "args": []
+    }
+  }
+}
+```
+
+## 使用
+
+调用工具：`ccfrank.ccf_rank`
+
+- 参数：`query: string`
+- 支持输入：简称（如 `PLDI`）、全称、DBLP 路径（如 `/conf/pldi/2024`）
+
+示例：`PLDI`、`ICSE`、`IEEE Transactions on Software Engineering`
+
+## 返回字段（核心）
+
+- `matched`：是否匹配
+- `rank`：`A | B | C | E | P | none`
+- `canonicalName`：标准名称
+- `venueType`：`conference | journal`
+- `matchedBy`：匹配方式（简称/全称/URL）
+- `sourceKey`：归一化来源键
+
+## 说明
+
+- 数据基于 CCF 2026 年 3 月版目录
+- 未收录返回 `none`
+- 依赖固定为 `ccfrank@4.5.5`，请校验 `integrity` 后再安装
+
+## 资源
+
+- GitHub: https://github.com/m2kar/CCFrank4dblp
+- CCF 官方目录: https://www.ccf.org.cn/Academic_Evaluation/By_category/

--- a/mcp/SKILL.md
+++ b/mcp/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ccfrank
 description: 查询会议/期刊的 CCF 等级。当用户提到 CCF 等级、论文评级、会议排名、期刊等级，或需要查询某个会议/期刊是 CCF-A/B/C 时使用此技能。支持通过会议简称（如 PLDI、ICSE）、全称、或 DBLP URL 查询。
-version: 1.0.3
+version: 1.0.4
 homepage: https://github.com/m2kar/CCFrank4dblp
 dependencies:
   npm:
@@ -11,11 +11,14 @@ dependencies:
       tarball: https://registry.npmjs.org/ccfrank/-/ccfrank-4.5.5.tgz
       sourceRepo: https://github.com/m2kar/CCFrank4dblp
 install:
-  method: local-npm
-  lockVersion: true
-  allowGlobalInstall: false
+  method: global-npm
+  lockVersion: false
+  allowGlobalInstall: true
   execution:
-    command: ./node_modules/.bin/ccfrank
+    command: npx
+    args:
+      - --no-install
+      - ccfrank
 ---
 
 # CCFrank
@@ -24,21 +27,18 @@ install:
 
 ## 安装配置（MCP）
 
-先在隔离目录安装固定版本（避免全局安装、避免运行时动态下载执行）：
+全局安装 CLI（安装命令不限制版本）：
 
 ```bash
-mkdir -p ~/.ccfrank-mcp
-cd ~/.ccfrank-mcp
-npm init -y
-npm install --save-exact ccfrank@4.5.5
+npm install -g ccfrank
 ```
 
 ```json
 {
   "mcpServers": {
     "ccfrank": {
-      "command": "/Users/<your-user>/.ccfrank-mcp/node_modules/.bin/ccfrank",
-      "args": []
+      "command": "npx",
+      "args": ["--no-install", "ccfrank"]
     }
   }
 }
@@ -66,7 +66,7 @@ npm install --save-exact ccfrank@4.5.5
 
 - 数据基于 CCF 2026 年 3 月版目录
 - 未收录返回 `none`
-- 依赖固定为 `ccfrank@4.5.5`，请校验 `integrity` 后再安装
+- 元数据依赖固定为 `ccfrank@4.5.5`（含 `integrity` / `tarball`）
 
 ## 资源
 

--- a/mcp/load-ccf-data.js
+++ b/mcp/load-ccf-data.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const vm = require("node:vm");
+
+const DATA_FILES = [
+  "js/ccf.js",
+  "data/ccfRankUrl.js",
+  "data/ccfRankFull.js",
+  "data/ccfRankAbbr.js",
+  "data/ccfRankDb.js",
+  "data/ccfFullUrl.js",
+  "data/ccfAbbrFull.js",
+];
+
+let cachedData = null;
+
+function loadCcfData() {
+  if (cachedData) {
+    return cachedData;
+  }
+
+  const context = vm.createContext({});
+
+  for (const relativePath of DATA_FILES) {
+    const absolutePath = path.resolve(__dirname, "..", relativePath);
+    const source = fs.readFileSync(absolutePath, "utf8");
+    vm.runInContext(source, context, { filename: absolutePath });
+  }
+
+  cachedData = vm.runInContext("ccf", context);
+
+  return cachedData;
+}
+
+module.exports = {
+  loadCcfData,
+};

--- a/mcp/lookup.js
+++ b/mcp/lookup.js
@@ -1,0 +1,274 @@
+"use strict";
+
+const { loadCcfData } = require("./load-ccf-data");
+
+let cachedIndexes = null;
+
+function normalizeText(value) {
+  return String(value)
+    .normalize("NFKC")
+    .trim()
+    .toUpperCase()
+    .replace(/[^0-9A-Z]+/g, " ")
+    .replace(/\s+/g, " ");
+}
+
+function normalizePath(value) {
+  if (!value) {
+    return null;
+  }
+
+  let pathValue = String(value).trim();
+  const queryIndex = pathValue.indexOf("?");
+  const hashIndex = pathValue.indexOf("#");
+  const cutIndex =
+    queryIndex === -1
+      ? hashIndex
+      : hashIndex === -1
+        ? queryIndex
+        : Math.min(queryIndex, hashIndex);
+
+  if (cutIndex !== -1) {
+    pathValue = pathValue.slice(0, cutIndex);
+  }
+
+  if (!pathValue.startsWith("/")) {
+    pathValue = `/${pathValue}`;
+  }
+
+  pathValue = decodeURIComponent(pathValue);
+  pathValue = pathValue.replace(/\/+$/g, "");
+
+  return pathValue || "/";
+}
+
+function inferVenueType(sourceKey) {
+  if (!sourceKey) {
+    return "unknown";
+  }
+
+  if (sourceKey.startsWith("/conf/")) {
+    return "conference";
+  }
+
+  if (sourceKey.startsWith("/journals/")) {
+    return "journal";
+  }
+
+  return "unknown";
+}
+
+function createIndexes() {
+  if (cachedIndexes) {
+    return cachedIndexes;
+  }
+
+  const ccf = loadCcfData();
+  const fullNameIndex = new Map();
+  const abbrIndex = new Map();
+
+  for (const fullName of Object.keys(ccf.fullUrl)) {
+    const normalized = normalizeText(fullName);
+    if (!fullNameIndex.has(normalized)) {
+      fullNameIndex.set(normalized, fullName);
+    }
+  }
+
+  for (const abbr of Object.keys(ccf.abbrFull)) {
+    if (!abbr) {
+      continue;
+    }
+
+    const normalized = normalizeText(abbr);
+    if (!abbrIndex.has(normalized)) {
+      abbrIndex.set(normalized, abbr);
+    }
+  }
+
+  for (const abbr of Object.values(ccf.rankAbbrName)) {
+    if (!abbr) {
+      continue;
+    }
+
+    const normalized = normalizeText(abbr);
+    if (!abbrIndex.has(normalized)) {
+      abbrIndex.set(normalized, abbr);
+    }
+  }
+
+  cachedIndexes = {
+    ccf,
+    fullNameIndex,
+    abbrIndex,
+  };
+
+  return cachedIndexes;
+}
+
+function resolveCanonicalSourceKey(candidate, ccf) {
+  if (!candidate) {
+    return null;
+  }
+
+  if (Object.hasOwn(ccf.rankUrl, candidate)) {
+    return candidate;
+  }
+
+  if (Object.hasOwn(ccf.rankDb, candidate)) {
+    return ccf.rankDb[candidate];
+  }
+
+  return null;
+}
+
+function expandPathCandidates(pathValue) {
+  const candidates = new Set();
+
+  function addCandidate(value) {
+    const normalized = normalizePath(value);
+    if (normalized) {
+      candidates.add(normalized);
+    }
+  }
+
+  const basePath = normalizePath(pathValue);
+  if (!basePath) {
+    return [];
+  }
+
+  addCandidate(basePath);
+  addCandidate(basePath.replace(/\/index\.html$/i, ""));
+  addCandidate(basePath.replace(/\.html$/i, ""));
+  addCandidate(basePath.replace(/([0-9]{1,4}(?:-[0-9]{1,4})?)$/i, ""));
+
+  if (basePath.includes("/db/")) {
+    const dbPath = basePath.slice(basePath.indexOf("/db/") + 3);
+    addCandidate(dbPath);
+    addCandidate(dbPath.replace(/\/index\.html$/i, ""));
+
+    const dbNoHtml = dbPath.replace(/\.html$/i, "");
+    addCandidate(dbNoHtml);
+    addCandidate(dbNoHtml.replace(/([0-9]{1,4}(?:-[0-9]{1,4})?)$/i, ""));
+  }
+
+  if (basePath.includes("/rec/")) {
+    const recStart = basePath.indexOf("/rec/") + 4;
+    const lastSlash = basePath.lastIndexOf("/");
+    if (lastSlash > recStart) {
+      addCandidate(basePath.slice(recStart, lastSlash));
+    }
+  }
+
+  return Array.from(candidates);
+}
+
+function looksLikeUrlOrPath(input) {
+  return (
+    /^https?:\/\//i.test(input) ||
+    /^dblp\.org\//i.test(input) ||
+    /^www\.dblp\.org\//i.test(input) ||
+    input.startsWith("/")
+  );
+}
+
+function tryLookupByUrl(input, ccf) {
+  let pathname = null;
+
+  if (/^https?:\/\//i.test(input)) {
+    pathname = new URL(input).pathname;
+  } else if (/^(dblp\.org|www\.dblp\.org)\//i.test(input)) {
+    pathname = new URL(`https://${input}`).pathname;
+  } else if (input.startsWith("/")) {
+    pathname = input;
+  }
+
+  if (!pathname) {
+    return null;
+  }
+
+  for (const candidate of expandPathCandidates(pathname)) {
+    const sourceKey = resolveCanonicalSourceKey(candidate, ccf);
+    if (sourceKey) {
+      return {
+        rankInfo: ccf.getRankInfo(sourceKey, "url"),
+        normalizedQuery: candidate,
+      };
+    }
+  }
+
+  return null;
+}
+
+function buildResult({
+  rankInfo = null,
+  matchedBy = "none",
+  normalizedQuery,
+  matched = false,
+}) {
+  const sourceKey = rankInfo ? rankInfo.sourceKey : null;
+
+  return {
+    matched,
+    rank: rankInfo ? rankInfo.ranks[0] || "none" : "none",
+    canonicalName: rankInfo ? rankInfo.canonicalName : null,
+    venueType: inferVenueType(sourceKey),
+    matchedBy,
+    normalizedQuery,
+    sourceKey,
+  };
+}
+
+function lookupVenue(query) {
+  if (typeof query !== "string") {
+    throw new TypeError("query must be a string");
+  }
+
+  const trimmed = query.trim();
+  if (!trimmed) {
+    throw new Error("query must not be empty");
+  }
+
+  const { ccf, fullNameIndex, abbrIndex } = createIndexes();
+
+  if (looksLikeUrlOrPath(trimmed)) {
+    const urlMatch = tryLookupByUrl(trimmed, ccf);
+    if (urlMatch) {
+      return buildResult({
+        rankInfo: urlMatch.rankInfo,
+        matchedBy: "url",
+        normalizedQuery: urlMatch.normalizedQuery,
+        matched: true,
+      });
+    }
+  }
+
+  const normalizedQuery = normalizeText(trimmed);
+  const fullName = fullNameIndex.get(normalizedQuery);
+  if (fullName) {
+    return buildResult({
+      rankInfo: ccf.getRankInfo(fullName),
+      matchedBy: "full_name",
+      normalizedQuery,
+      matched: true,
+    });
+  }
+
+  const abbr = abbrIndex.get(normalizedQuery);
+  if (abbr) {
+    return buildResult({
+      rankInfo: ccf.getRankInfo(abbr, "abbr"),
+      matchedBy: "abbr",
+      normalizedQuery,
+      matched: true,
+    });
+  }
+
+  return buildResult({
+    normalizedQuery: looksLikeUrlOrPath(trimmed) ? trimmed : normalizedQuery,
+  });
+}
+
+module.exports = {
+  lookupVenue,
+  normalizeText,
+};

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+"use strict";
+
+const { McpServer } = require("@modelcontextprotocol/sdk/server/mcp.js");
+const {
+  StdioServerTransport,
+} = require("@modelcontextprotocol/sdk/server/stdio.js");
+const z = require("zod/v4");
+const { version } = require("../manifest.json");
+
+const { lookupVenue } = require("./lookup");
+
+const server = new McpServer({
+  name: "ccfrank-mcp",
+  version,
+});
+
+server.registerTool(
+  "ccf_rank",
+  {
+    title: "Lookup CCF Rank",
+    description:
+      "Look up the CCF rank for a conference or journal by exact/normalized name, abbreviation, or DBLP-style URL/path.",
+    inputSchema: {
+      query: z
+        .string()
+        .min(1)
+        .describe(
+          "Conference or journal name, abbreviation, or DBLP-style URL/path.",
+        ),
+    },
+    outputSchema: {
+      matched: z.boolean(),
+      rank: z.enum(["A", "B", "C", "E", "P", "none"]),
+      canonicalName: z.string().nullable(),
+      venueType: z.enum(["conference", "journal", "unknown"]),
+      matchedBy: z.enum(["full_name", "abbr", "url", "none"]),
+      normalizedQuery: z.string(),
+      sourceKey: z.string().nullable(),
+    },
+    annotations: {
+      title: "Lookup CCF Rank",
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  },
+  async ({ query }) => {
+    try {
+      const result = lookupVenue(query);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: formatLookupText(query, result),
+          },
+        ],
+        structuredContent: result,
+      };
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Lookup failed: ${error.message}`,
+          },
+        ],
+        structuredContent: {
+          matched: false,
+          rank: "none",
+          canonicalName: null,
+          venueType: "unknown",
+          matchedBy: "none",
+          normalizedQuery: typeof query === "string" ? query.trim() : "",
+          sourceKey: null,
+        },
+        isError: true,
+      };
+    }
+  },
+);
+
+function formatLookupText(query, result) {
+  if (!result.matched) {
+    return `No CCF rank found for "${query}".`;
+  }
+
+  return [
+    `CCF ${result.rank}`,
+    `Name: ${result.canonicalName}`,
+    `Type: ${result.venueType}`,
+    `Matched by: ${result.matchedBy}`,
+    `Source key: ${result.sourceKey}`,
+  ].join("\n");
+}
+
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((error) => {
+  console.error("CCFrank MCP server failed:", error);
+  process.exit(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,28 @@
 {
-  "name": "CCFrank4dblp",
-  "version": "4.5.5",
+  "name": "ccfrank-mcp",
+  "version": "4.5.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "ccfrank-mcp",
+      "version": "4.5.6",
+      "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
         "zod": "^4.3.6"
+      },
+      "bin": {
+        "ccfrank-mcp": "mcp/server.js"
       },
       "devDependencies": {
         "git-format-staged": "^3.1.1",
         "husky": "^9.1.6",
         "lint-staged": "^15.2.10",
         "prettier": "3.3.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@hono/node-server": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,117 @@
 {
   "name": "CCFrank4dblp",
+  "version": "4.5.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "zod": "^4.3.6"
+      },
       "devDependencies": {
         "git-format-staged": "^3.1.1",
         "husky": "^9.1.6",
         "lint-staged": "^15.2.10",
         "prettier": "3.3.3"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-escapes": {
@@ -53,6 +156,47 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -64,6 +208,44 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chalk": {
@@ -129,11 +311,67 @@
         "node": ">=18"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
       "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -162,12 +400,50 @@
         }
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/emoji-regex": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
       "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -182,12 +458,78 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/execa": {
       "version": "8.0.1",
@@ -213,6 +555,106 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
+      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -226,6 +668,71 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
@@ -237,6 +744,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-stream": {
@@ -260,6 +804,71 @@
       "license": "MIT",
       "bin": {
         "git-format-staged": "git-format-staged"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/human-signals": {
@@ -288,6 +897,46 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
@@ -311,6 +960,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
@@ -328,8 +983,28 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/lilconfig": {
       "version": "3.1.2",
@@ -443,6 +1118,36 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -462,6 +1167,31 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/mimic-fn": {
@@ -494,8 +1224,16 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
@@ -526,6 +1264,48 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
@@ -542,14 +1322,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/picomatch": {
@@ -578,6 +1376,15 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
@@ -592,6 +1399,67 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/restore-cursor": {
@@ -634,11 +1502,117 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -651,10 +1625,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/signal-exit": {
@@ -685,6 +1730,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/string-argv": {
@@ -757,11 +1811,51 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -791,6 +1885,12 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/yaml": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
@@ -802,6 +1902,24 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,27 @@
 {
+  "name": "ccfrank-mcp",
+  "version": "4.5.6",
+  "description": "CCFrank MCP server for looking up CCF ranks from embedded data.",
+  "license": "MIT",
+  "bin": {
+    "ccfrank-mcp": "mcp/server.js"
+  },
+  "files": [
+    "mcp",
+    "data/ccfAbbrFull.js",
+    "data/ccfFullUrl.js",
+    "data/ccfRankAbbr.js",
+    "data/ccfRankDb.js",
+    "data/ccfRankFull.js",
+    "data/ccfRankUrl.js",
+    "js/ccf.js",
+    "manifest.json",
+    "README.md",
+    "LICENSE"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
   "devDependencies": {
     "git-format-staged": "^3.1.1",
     "husky": "^9.1.6",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "ccfrank-mcp",
-  "version": "4.5.6",
-  "description": "CCFrank MCP server for looking up CCF ranks from embedded data.",
+  "name": "ccfrank",
+  "version": "4.5.5",
+  "description": "CCFrank for looking up CCF ranks.",
   "license": "MIT",
   "bin": {
-    "ccfrank-mcp": "mcp/server.js"
+    "ccfrank": "mcp/server.js"
   },
   "files": [
     "mcp",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,15 @@
     "prettier": "3.3.3"
   },
   "scripts": {
-    "prepare": "husky"
+    "prepare": "husky",
+    "mcp": "node ./mcp/server.js",
+    "test": "node --test"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "zod": "^4.3.6"
   }
 }

--- a/test/lookup.test.js
+++ b/test/lookup.test.js
@@ -1,0 +1,97 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { lookupVenue } = require("../mcp/lookup");
+
+test("lookup by normalized full name", () => {
+  const result = lookupVenue("  ACM Transactions on Computer Systems ");
+
+  assert.equal(result.matched, true);
+  assert.equal(result.rank, "A");
+  assert.equal(result.canonicalName, "ACM Transactions on Computer Systems");
+  assert.equal(result.venueType, "journal");
+  assert.equal(result.matchedBy, "full_name");
+});
+
+test("lookup by abbreviation", () => {
+  const result = lookupVenue("SIGCOMM");
+
+  assert.equal(result.matched, true);
+  assert.equal(result.rank, "A");
+  assert.equal(result.venueType, "conference");
+  assert.equal(result.matchedBy, "abbr");
+  assert.equal(
+    result.canonicalName,
+    "ACM International Conference on Applications, Technologies, Architectures, and Protocols for Computer Communication",
+  );
+});
+
+test("lookup by dblp venue url", () => {
+  const result = lookupVenue("https://dblp.org/db/conf/sc/index.html");
+
+  assert.equal(result.matched, true);
+  assert.equal(result.rank, "A");
+  assert.equal(result.venueType, "conference");
+  assert.equal(result.matchedBy, "url");
+  assert.equal(
+    result.canonicalName,
+    "International Conference for High Performance Computing, Networking, Storage, and Analysis",
+  );
+});
+
+test("lookup by dblp record url", () => {
+  const result = lookupVenue("https://dblp.org/rec/conf/sigcomm/Smith24");
+
+  assert.equal(result.matched, true);
+  assert.equal(result.rank, "A");
+  assert.equal(result.venueType, "conference");
+  assert.equal(result.matchedBy, "url");
+});
+
+test("lookup handles punctuation normalization", () => {
+  const result = lookupVenue(
+    "IEEE Transactions on Very Large Scale Integration VLSI Systems",
+  );
+
+  assert.equal(result.matched, true);
+  assert.equal(result.rank, "B");
+  assert.equal(result.venueType, "journal");
+});
+
+test("lookup handles ampersand and plus normalization", () => {
+  const date = lookupVenue("Design Automation Test in Europe");
+  const codes = lookupVenue("CODES ISSS");
+
+  assert.equal(date.matched, true);
+  assert.equal(date.rank, "B");
+  assert.equal(codes.matched, true);
+  assert.equal(codes.rank, "B");
+});
+
+test("lookup returns none for misses", () => {
+  const result = lookupVenue("Totally Fake Conference on Fake Systems");
+
+  assert.deepEqual(result, {
+    matched: false,
+    rank: "none",
+    canonicalName: null,
+    venueType: "unknown",
+    matchedBy: "none",
+    normalizedQuery: "TOTALLY FAKE CONFERENCE ON FAKE SYSTEMS",
+    sourceKey: null,
+  });
+});
+
+test("lookup preserves expanded and preprint ranks", () => {
+  const expanded = lookupVenue("Cybersecurity");
+  const preprint = lookupVenue("ARXIV");
+
+  assert.equal(expanded.rank, "B");
+  assert.equal(preprint.rank, "P");
+});
+
+test("lookup rejects empty queries", () => {
+  assert.throws(() => lookupVenue("   "), /query must not be empty/);
+});

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,190 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const path = require("node:path");
+const { spawn } = require("node:child_process");
+
+function encodeMessage(message) {
+  return Buffer.from(`${JSON.stringify(message)}\n`, "utf8");
+}
+
+function createMessageReader(child) {
+  let buffer = "";
+  const waiters = [];
+
+  child.stdout.on("data", (chunk) => {
+    buffer += chunk.toString("utf8");
+
+    while (true) {
+      const newlineIndex = buffer.indexOf("\n");
+      if (newlineIndex === -1) {
+        break;
+      }
+
+      const payload = buffer.slice(0, newlineIndex).trim();
+      buffer = buffer.slice(newlineIndex + 1);
+      if (!payload) {
+        continue;
+      }
+
+      const waiter = waiters.shift();
+      if (waiter) {
+        waiter.resolve(JSON.parse(payload));
+      }
+    }
+  });
+
+  child.on("error", (error) => {
+    while (waiters.length > 0) {
+      waiters.shift().reject(error);
+    }
+  });
+
+  child.on("exit", (code, signal) => {
+    if (code === 0 || signal === "SIGTERM") {
+      return;
+    }
+
+    const error = new Error(
+      `MCP server exited unexpectedly: code=${code} signal=${signal}`,
+    );
+    while (waiters.length > 0) {
+      waiters.shift().reject(error);
+    }
+  });
+
+  return function readNext() {
+    return new Promise((resolve, reject) => {
+      waiters.push({ resolve, reject });
+    });
+  };
+}
+
+test("stdio MCP server initializes and handles lookups", async () => {
+  const serverPath = path.resolve(__dirname, "..", "mcp", "server.js");
+  const child = spawn(process.execPath, [serverPath], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const readNext = createMessageReader(child);
+
+  child.stdin.write(
+    encodeMessage({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: {
+          name: "test-client",
+          version: "0.0.0",
+        },
+      },
+    }),
+  );
+
+  const initializeResponse = await readNext();
+  assert.equal(initializeResponse.id, 1);
+  assert.equal(initializeResponse.result.protocolVersion, "2025-06-18");
+  assert.equal(typeof initializeResponse.result.capabilities, "object");
+  assert.equal(typeof initializeResponse.result.serverInfo, "object");
+
+  child.stdin.write(
+    encodeMessage({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    }),
+  );
+
+  child.stdin.write(
+    encodeMessage({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/list",
+      params: {},
+    }),
+  );
+
+  const toolsResponse = await readNext();
+  assert.equal(toolsResponse.id, 2);
+  assert.equal(toolsResponse.result.tools.length, 1);
+  assert.equal(toolsResponse.result.tools[0].name, "ccf_rank");
+
+  child.stdin.write(
+    encodeMessage({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "tools/call",
+      params: {
+        name: "ccf_rank",
+        arguments: {
+          query: "SIGCOMM",
+        },
+      },
+    }),
+  );
+
+  const callResponse = await readNext();
+  assert.equal(callResponse.id, 3);
+  assert.equal(callResponse.result.isError, undefined);
+  assert.equal(callResponse.result.structuredContent.rank, "A");
+  assert.equal(callResponse.result.structuredContent.matchedBy, "abbr");
+  assert.match(callResponse.result.content[0].text, /CCF A/);
+
+  child.stdin.end();
+});
+
+test("stdio MCP server returns tool-level errors for invalid queries", async () => {
+  const serverPath = path.resolve(__dirname, "..", "mcp", "server.js");
+  const child = spawn(process.execPath, [serverPath], {
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  const readNext = createMessageReader(child);
+
+  child.stdin.write(
+    encodeMessage({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: {
+          name: "test-client",
+          version: "0.0.0",
+        },
+      },
+    }),
+  );
+  await readNext();
+
+  child.stdin.write(
+    encodeMessage({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    }),
+  );
+
+  child.stdin.write(
+    encodeMessage({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: {
+        name: "ccf_rank",
+        arguments: {
+          query: "   ",
+        },
+      },
+    }),
+  );
+
+  const errorResponse = await readNext();
+  assert.equal(errorResponse.id, 2);
+  assert.equal(errorResponse.result.isError, true);
+  assert.equal(errorResponse.result.structuredContent.rank, "none");
+  assert.match(errorResponse.result.content[0].text, /Lookup failed/);
+
+  child.stdin.end();
+});


### PR DESCRIPTION
## Summary
- add a local stdio MCP server with a `ccf_rank` tool
- reuse the existing CCFrank rank lookup logic and add MCP-focused lookup/server tests
- document the Claude Code `.mcp.json` project configuration
- include npm package metadata needed for publishing the MCP entrypoint

## Testing
- npm test